### PR TITLE
Fixes for Vagrantfile to work on new systems (box_url needed)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,8 @@ Vagrant.configure("2") do |global_config|
     arvados_cluster.each_pair do |name, options|
         global_config.vm.define name do |config|
             #VM configurations
-            config.vm.box = "centos6_64"
+            config.vm.box = "centos/7"
+            config.vm.box_url = "centos/7"
             config.vm.hostname = options[:hostname]
             config.vm.network :private_network, ip: options[:ipaddress]
 
@@ -79,8 +80,8 @@ Vagrant.configure("2") do |global_config|
 
             # Ansible provision
             config.vm.provision "ansible" do |ansible|
-                ansible.playbook = "arvados-ansible/arvados.yaml"
-                ansible.inventory_path = "arvados-ansible/cluster-vm"
+                ansible.playbook = "arvados.yaml"
+                ansible.inventory_path = "cluster-vm"
             end
         end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,8 +59,8 @@ Vagrant.configure("2") do |global_config|
     arvados_cluster.each_pair do |name, options|
         global_config.vm.define name do |config|
             #VM configurations
-            config.vm.box = "centos/7"
-            config.vm.box_url = "centos/7"
+            config.vm.box_url = "boxcutter/centos64"
+            config.vm.box = "boxcutter/centos64"
             config.vm.hostname = options[:hostname]
             config.vm.network :private_network, ip: options[:ipaddress]
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,8 +59,8 @@ Vagrant.configure("2") do |global_config|
     arvados_cluster.each_pair do |name, options|
         global_config.vm.define name do |config|
             #VM configurations
-            config.vm.box_url = "boxcutter/centos64"
-            config.vm.box = "boxcutter/centos64"
+            config.vm.box_url = "puppetlabs/centos-6.6-64-puppet"
+            config.vm.box = "puppetlabs/centos-6.6-64-puppet"
             config.vm.hostname = options[:hostname]
             config.vm.network :private_network, ip: options[:ipaddress]
 


### PR DESCRIPTION
If no `box_url` is provided, `vagrant up` on new machines will fail due to "box not present" errors. With `config.box.box_url`, the box gets downloaded automatically from Vagrant Cloud.

And while we are at it, why not go for CentOS 7 instead? ;)
