### PR TITLE
Arvados git

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ install to deploy an Arvados cluster.
 
 ## How to run
 
+### Quickstart
+
+Make sure you tweaked `group_vars/all` as indicated in next section, then run:
+
+```
+ansible-galaxy install -r requirements.yml --ignore-errors --force -p roles && vagrant up
+```
+
 ### Variables
 Edit the file `group_vars/all` and set username and password that ansible will use to deploy the roles.
 Have in mind that this user **needs** root privileges to edit system files.

--- a/arvados.yaml
+++ b/arvados.yaml
@@ -1,9 +1,4 @@
 # Main playbook to deploy an Arvados cluster
-- hosts: localhost
-  name: make sure ansible-galaxy requirements are installed
-  tasks:
-    - shell: ansible-galaxy install -r requirements.yml --ignore-errors --force -p roles
-
 - hosts: all
   sudo_user: "root"
   roles:
@@ -24,6 +19,7 @@
       - arvados
       - passenger
       - arvados-api
+      - groover.gitolite
 #      - arvados-crunch
 #      - arvados-git
 #      - arvados-workbench

--- a/arvados.yaml
+++ b/arvados.yaml
@@ -19,7 +19,7 @@
       - arvados
       - passenger
       - arvados-api
+      - arvados-git
       - groover.gitolite
 #      - arvados-crunch
-#      - arvados-git
 #      - arvados-workbench

--- a/arvados.yaml
+++ b/arvados.yaml
@@ -21,5 +21,5 @@
       - arvados-api
       - arvados-git
       - groover.gitolite
-#      - arvados-crunch
 #      - arvados-workbench
+#      - arvados-crunch

--- a/group_vars/all
+++ b/group_vars/all
@@ -5,5 +5,8 @@ password: vagrant
 # purposes and are by no means secure for a production cluster
 uuid_prefix: abcde
 uuid_prefix_sso: fghij
+secret_token: yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 secret_token_sso: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+api_token: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+
 db_password: abcdefghijklmnopqrstuvwxyz012345689

--- a/group_vars/all
+++ b/group_vars/all
@@ -10,3 +10,7 @@ secret_token_sso: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 api_token: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 
 db_password: abcdefghijklmnopqrstuvwxyz012345689
+
+## Arvados-git
+gitolite_user_home: '/var/lib/arvados/git'
+gitolite_user_name: 'gitolite3'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,3 @@
 - src: rvm_io.rvm1-ruby
 - src: ANXS.postgresql
+- src: groover.gitolite

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
 - src: rvm_io.rvm1-ruby
-- src: ANXS.postgresql
 - src: groover.gitolite

--- a/roles/arvados-api/defaults/main.yml
+++ b/roles/arvados-api/defaults/main.yml
@@ -3,9 +3,4 @@ dbname: arvados_production
 dbuser: arvados
 dbpassword: Bo9phahb
 rvm1_gpg_key_server: 'hkp://pgp.mit.edu'
-postgresql_default_auth_method: 'md5'
-postgresql_pg_hba_default:
-  - { type: local, database: all, user: '{{ postgresql_admin_user }}', address: '', method: '{{ postgresql_default_auth_method }}', comment: '' }
-  - { type: local, database: all, user: all, address: '',             method: '{{ postgresql_default_auth_method }}', comment: '"local" is for Unix domain socket connections only' }
-  - { type: host,  database: all, user: all, address: '127.0.0.1/32', method: '{{ postgresql_default_auth_method }}', comment: 'IPv4 local connections:' }
-  - { type: host,  database: all, user: all, address: '::1/128',      method: '{{ postgresql_default_auth_method }}', comment: 'IPv6 local connections:' }
+postgresql_default_auth_method: 'trust'

--- a/roles/arvados-api/tasks/main.yml
+++ b/roles/arvados-api/tasks/main.yml
@@ -32,9 +32,4 @@
 - name: Copy API application config
   sudo: yes
   template: src=application.j2 dest=/etc/arvados/api/application.yml
-
-- name: "Create arvados-api user and internal git repos"
-  file: path="{{ item }}" state=directory mode=0700
-  with_items:
-    - "/var/lib/arvados/internal.git"
-    - "/var/lib/arvados/git/repositories"
+  notify: restart nginx

--- a/roles/arvados-api/tasks/main.yml
+++ b/roles/arvados-api/tasks/main.yml
@@ -18,9 +18,9 @@
     - arvados-api-server
 
 - name: "Add Postgresql database credentials"
-  include: postgresql.yml
-  notify:
-    - restart postgresql
+ include: postgresql.yml
+ notify:
+   - restart postgresql
 
 - name: "Create arvados-api app and database config"
   file: path="/etc/arvados/api" state=directory mode=0700

--- a/roles/arvados-git/defaults/main.yml
+++ b/roles/arvados-git/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for arvados-git
+gitolite_runit: "/etc/sv/arvados-git-httpd"

--- a/roles/arvados-git/handlers/main.yml
+++ b/roles/arvados-git/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for arvados-git

--- a/roles/arvados-git/tasks/main.yml
+++ b/roles/arvados-git/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# tasks file for arvados-git
+- name: Install runit external yum repo
+  shell: curl -s https://packagecloud.io/install/repositories/imeyer/runit/script.rpm.sh | sudo bash
+
+- name: Install Arvados GIT server and dependencies
+  yum: name={{ item }} state=latest update_cache=yes
+  with_items:
+    - git
+#    - perl-Data-Dumper XXX: not found in yum, should be installed via cpanm?
+    - openssh-server
+    - gitolite3
+    - arvados-git-httpd
+    - runit
+
+- name: "Create arvados-api user and internal git repos"
+  file: path="{{ item }}" state=directory mode=0700
+  with_items:
+    - "/var/lib/arvados/internal.git"
+    - "/var/lib/arvados/git/repositories"
+
+- name: Add git user and generate SSH key
+  user: name=git shell=/bin/bash groups={{ gitolite_user_name }} home="{{ gitolite_user_home }}" generate_ssh_key=yes ssh_key_bits=2048
+
+- name: Create arvados git dir
+  file: name="{{ gitolite_user_home }}" state=directory owner="{{ gitolite_user_name }}" group="{{ gitolite_user_name }}"
+
+- name: Create arvados git (bin) dir
+  file: name="{{ gitolite_user_home }}/bin" state=directory owner="{{ gitolite_user_name }}" group="{{ gitolite_user_name }}"
+
+- name: Create gitolite runit service dir
+  file: name="{{ gitolite_runit }}" state=directory
+
+- name: Setting up runit config for gitolite
+  template: src="gitolite.runit.j2" dest="{{ gitolite_runit }}/run" mode=700

--- a/roles/arvados-git/tasks/main.yml
+++ b/roles/arvados-git/tasks/main.yml
@@ -17,10 +17,10 @@
   file: path="{{ item }}" state=directory mode=0700
   with_items:
     - "/var/lib/arvados/internal.git"
-    - "/var/lib/arvados/git/repositories"
+    - "{{ gitolite_user_home }}/repositories"
 
 - name: Add git user and generate SSH key
-  user: name=git shell=/bin/bash groups={{ gitolite_user_name }} home="{{ gitolite_user_home }}" generate_ssh_key=yes ssh_key_bits=2048
+  user: name={{ gitolite_user_name }} shell=/bin/bash groups={{ gitolite_user_name }} home="{{ gitolite_user_home }}" generate_ssh_key=yes ssh_key_bits=2048
 
 - name: Create arvados git dir
   file: name="{{ gitolite_user_home }}" state=directory owner="{{ gitolite_user_name }}" group="{{ gitolite_user_name }}"

--- a/roles/arvados-git/templates/gitolite.runit.j2
+++ b/roles/arvados-git/templates/gitolite.runit.j2
@@ -1,0 +1,6 @@
+#!/bin/sh
+export ARVADOS_API_HOST="{{ uuid_prefix }}".your.domain
+export GITOLITE_HTTP_HOME="{{ gitolite_user_home }}"
+export GL_BYPASS_ACCESS_CHECKS=1
+export PATH="$PATH:{{ gitolite_user_home }}/bin"
+exec chpst -u git:git arvados-git-httpd -address=:9001 -git-command="{{ gitolite_user_home }}"/gitolite/src/gitolite-shell -repo-root="{{ gitolite_user_home }}"/repositories 2>&1

--- a/roles/arvados-git/vars/main.yml
+++ b/roles/arvados-git/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for arvados-git


### PR DESCRIPTION
Here it is, next step into the Arvados installation docs:

http://doc.arvados.org/install/install-arv-git-httpd.html

Ansible-galaxy cannot run inside the ansible roles, has to be performed manually beforehand (AFAIK), see README.

I observed that the nginx tasks should be abstracted away as a role as well. I'll have a look at it tomorrow. I'm pullrequesting so that @guillermo-carrasco can catch-up, right now there is an issue with directory permissions for gitolite:

```
TASK: [groover.gitolite | Initialize gitolite] ********************************
failed: [10.10.10.2] => {"failed": true, "rc": 258}
msg: cannot change to directory '/var/lib/arvados/git': path does not exist

FATAL: all hosts have already failed -- aborting
```
