### PR TITLE
sudo=yes for arvados-git role

### DIFF
--- a/arvados.yaml
+++ b/arvados.yaml
@@ -14,6 +14,7 @@
 
 - hosts: workbench
   sudo_user: "root"
+  sudo: yes
   vars_files:
       - roles/arvados-sso/vars/main.yaml
   roles:


### PR DESCRIPTION
You'll face this:

```
TASK: [arvados-git | Install Arvados GIT server and dependencies] *************
failed: [10.10.10.2] => (item=git,openssh-server,gitolite3,arvados-git-httpd,runit) => {"changed": true, "failed": true, "item": "git,openssh-server,gitolite3,arvados-git-httpd,runit", "rc": 2, "results": ["All packages providing git are up to date", "Loaded plugins: fastestmirror, security\nLoaded plugins: fastestmirror, security\n"]}
msg: You need to be root to perform this command.
You need to be root to perform this command.


FATAL: all hosts have already failed -- aborting
```
